### PR TITLE
Fix PlcAppSystemInfo fields failing on TwinCAT 3 usermode runtime

### DIFF
--- a/TwinSharp/Extensions.cs
+++ b/TwinSharp/Extensions.cs
@@ -37,6 +37,27 @@ namespace TwinSharp
         }
 
         /// <summary>
+        /// Reads a ULINT or UDINT symbol as ulong. On the TwinCAT usermode runtime some
+        /// counter fields are exposed as UDINT (4 bytes) instead of ULINT (8 bytes).
+        /// Tries to read 8 bytes first; if the runtime returns only 4 bytes it retries
+        /// as uint and widens the result.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="handle"></param>
+        /// <returns></returns>
+        public static ulong ReadUlintOrUdint(this AdsClient client, uint handle)
+        {
+            try
+            {
+                return client.ReadAny<ulong>(handle);
+            }
+            catch (AdsErrorException)
+            {
+                return client.ReadAny<uint>(handle);
+            }
+        }
+
+        /// <summary>
         /// Converts a byte array to a uint.
         /// </summary>
         /// <param name="buffer"></param>

--- a/TwinSharp/PLC/PlcAppSystemInfo.cs
+++ b/TwinSharp/PLC/PlcAppSystemInfo.cs
@@ -28,7 +28,7 @@ namespace TwinSharp.PLC
             get
             {
                 uint handle = GetOrCreateVariableHandle("TwinCAT_SystemInfoVarList._AppInfo.ObjId");
-                return client.ReadAny<ulong>(handle);
+                return client.ReadUlintOrUdint(handle);
             }
         }
 
@@ -154,7 +154,7 @@ namespace TwinSharp.PLC
             get
             {
                 uint handle = GetOrCreateVariableHandle("TwinCAT_SystemInfoVarList._AppInfo.TaskCnt");
-                return client.ReadAny<ulong>(handle);
+                return client.ReadUlintOrUdint(handle);
             }
         }
 
@@ -166,7 +166,7 @@ namespace TwinSharp.PLC
             get
             {
                 uint handle = GetOrCreateVariableHandle("TwinCAT_SystemInfoVarList._AppInfo.OnlineChangeCnt");
-                return client.ReadAny<ulong>(handle);
+                return client.ReadUlintOrUdint(handle);
             }
         }
 


### PR DESCRIPTION
## Problem

On the TwinCAT 3 [usermode runtime](https://www.beckhoff.com/en-en/products/automation/twincat/tcxxxx-twincat-3-base/tc1700.html) (the Windows soft PLC, without real-time kernel extensions), the `ObjId`, `TaskCnt` and `OnlineChangeCnt` fields in `PlcAppSystemInfo` are exposed over ADS as UDINT (4 bytes) rather than ULINT (8 bytes) as on the standard kernel-mode runtime.

Calling `ReadAny<ulong>()` against a 4-byte symbol throws at runtime:

    Marshalling size is '8' bytes, but read data is '4' bytes.
    Cannot marshal type 'System.UInt64'!

This causes `PLC.AppInfo` to be unusable on the usermode runtime.

## Fix

Add a `ReadUlintOrUdint()` extension method on `AdsClient` (alongside the existing `ReadDateTime` helper in `Extensions.cs`) that attempts a `ulong` read and, on `AdsErrorException`, retries as `uint` and widens the result. The three affected properties in `PlcAppSystemInfo` now use this helper.

 ## Testing

Verified manually against two live targets:
- TwinCAT 3 usermode runtime on Windows 11 — previously failed, now passes
- TwinCAT 3 kernel-mode runtime 4026.17  — continues to pass